### PR TITLE
Develop

### DIFF
--- a/karoloke/jukebox_router.py
+++ b/karoloke/jukebox_router.py
@@ -197,7 +197,13 @@ def playlist_qr():
     except socket.gaierror:
         local_ip = 'localhost'
     port = request.environ.get('SERVER_PORT', request.host.split(':')[-1])
-    playlist_url = f"{request.scheme}://{local_ip}:{port}{url_for('playlist')}"
+    
+    # Original playlist route logic (commented for future use)
+    # playlist_url = f"{request.scheme}://{local_ip}:{port}{url_for('playlist')}"
+    
+    # Temporary solution: QR code points to a PDF file
+    playlist_url = "https://drive.google.com/file/d/1Mv06a6NNCY1udz38Q2fYjKdg57lI1hJr/view?usp=sharing"
+    
     img = qrcode.make(playlist_url)
     buf = io.BytesIO()
     img.save(buf, 'PNG')

--- a/karoloke/jukebox_router.py
+++ b/karoloke/jukebox_router.py
@@ -197,13 +197,13 @@ def playlist_qr():
     except socket.gaierror:
         local_ip = 'localhost'
     port = request.environ.get('SERVER_PORT', request.host.split(':')[-1])
-    
+
     # Original playlist route logic (commented for future use)
     # playlist_url = f"{request.scheme}://{local_ip}:{port}{url_for('playlist')}"
-    
+
     # Temporary solution: QR code points to a PDF file
-    playlist_url = "https://drive.google.com/file/d/1Mv06a6NNCY1udz38Q2fYjKdg57lI1hJr/view?usp=sharing"
-    
+    playlist_url = 'https://drive.google.com/file/d/1Mv06a6NNCY1udz38Q2fYjKdg57lI1hJr/view?usp=sharing'
+
     img = qrcode.make(playlist_url)
     buf = io.BytesIO()
     img.save(buf, 'PNG')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "karoloke"
-version = "2.0.0"
+version = "2.1.0"
 description = "A simple karaoke framework to your party!"
 authors = [
     {name = "Antonio Senra",email = "acsenrafilho@gmail.com"}

--- a/tests/test_jukebox_router.py
+++ b/tests/test_jukebox_router.py
@@ -52,21 +52,21 @@ def test_playlist_qr(client):
     assert response.mimetype == 'image/png'
 
 
-@pytest.mark.skipif(
-    sys.platform.startswith('darwin'),
-    reason='QR code IP test skipped on macOS',
-)
-def test_playlist_qr_is_with_ip_address(client):
-    response = client.get('/playlist_qr')
-    assert response.status_code == 200
+# @pytest.mark.skipif(
+#     sys.platform.startswith('darwin'),
+#     reason='QR code IP test skipped on macOS',
+# )
+# def test_playlist_qr_is_with_ip_address(client):
+#     response = client.get('/playlist_qr')
+#     assert response.status_code == 200
 
-    # Decode the QR code from the response PNG image
-    img = Image.open(BytesIO(response.data))
-    decoded = pyzbar.decode(img)
-    ip_pattern = re.compile(rb'https?://(\d{1,3}\.){3}\d{1,3}(:\d+)?')
-    assert any(
-        d.type == 'QRCODE' and ip_pattern.search(d.data) for d in decoded
-    )
+#     # Decode the QR code from the response PNG image
+#     img = Image.open(BytesIO(response.data))
+#     decoded = pyzbar.decode(img)
+#     ip_pattern = re.compile(rb'https?://(\d{1,3}\.){3}\d{1,3}(:\d+)?')
+#     assert any(
+#         d.type == 'QRCODE' and ip_pattern.search(d.data) for d in decoded
+#     )
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
This pull request temporarily changes the behavior of the playlist QR code feature to point to a static PDF link instead of the dynamic playlist route. Corresponding test code that checked for IP addresses in the QR code has been commented out to reflect this change.

**Playlist QR code changes:**

* The `playlist_qr` route in `jukebox_router.py` now generates a QR code that links to a static Google Drive PDF instead of the local playlist URL. The original logic is commented for future reference.

**Test updates:**

* The test `test_playlist_qr_is_with_ip_address` that verified the QR code points to an IP address has been commented out, since the QR code no longer points to a dynamic IP-based URL.